### PR TITLE
Change TWFY branch name to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ init-submodules:
 	git submodule update --init
 
 update-twfy:
-	cd twfy && git checkout master && git pull origin master
+	cd twfy && git checkout main && git pull origin main
 	git status
 	git add --patch twfy
 	git commit -m "Update to latest TheyWorkForYou"


### PR DESCRIPTION
update openaustralia code to pull TWFY (they work for you) from the `main` branch instead of `master`

(master no longer exists)