### PR TITLE
Detect if submodules have never been cloned before trying to update them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 ALL: vagrant
 SHELL := /usr/bin/env bash
 
+twfy/.git:
+	git submodule init && git submodule update
+
 deploy-local-vagrant:
 	bundle exec cap -S stage=development deploy
 
@@ -26,7 +29,7 @@ production-parse-members:
 init-submodules:
 	git submodule update --init
 
-update-twfy:
+update-twfy: twfy/.git
 	cd twfy && git checkout main && git pull origin main
 	git status
 	git add --patch twfy


### PR DESCRIPTION
## What does this do?
If the user has just checked out the repo for the first time, they need to do an initial submodule update before they can work with the submodule states. This detects the case where that update hasn't been done, and does it automatically if needed.

## Why was this needed?
I tried to use `make update-twfy` but didn't have the submodule checked out

## Implementation/Deploy Steps (Optional)
None. No doc changes needed, this integrates into the existing documented processes.

## Notes to reviewer (Optional)
