### PR TITLE
renaming and changing branches for new staging server

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -26,18 +26,29 @@ set :user, "deploy"
 #   Port 1234
 # This will change the port for all ssh commands on that server which saves a whole lot of typing
 
-if stage == "production"
-  role :web, "openaustralia.org.au"
-  set :deploy_to, "/srv/www/production"
+case stage
+when "staging-new"
+	role :web, "staging.openaustralia.org.au"
+	set :deploy_to, "/srv/www/staging"
+	set :branch, "staging"
+when "production-new"
+	role :web, "staging.openaustralia.org.au" # TODO: Change this once DNS points to the new server
+	set :deploy_to, "/srv/www/production"
+	set :branch, "staging"
+when "production"
+	role :web, "openaustralia.org.au"
+	set :deploy_to, "/srv/www/production"
 	set :branch, "main"
-elsif stage == "test"
-  role :web, "openaustralia.org.au"
-  set :deploy_to, "/srv/www/staging"
-  set :branch, "test"
-elsif stage == "development"
-  role :web, "openaustralia.org.au.test"
-  set :deploy_to, "/srv/www/production"
+when "test"
+	role :web, "openaustralia.org.au"
+	set :deploy_to, "/srv/www/staging"
+	set :branch, "main"
+when "development"
+	role :web, "openaustralia.org.au.test"
+	set :deploy_to, "/srv/www/production"
+	# Uses the user's current branch
 end
+
 set :bundle_gemfile, "openaustralia-parser/Gemfile"
 
 load 'deploy' if respond_to?(:namespace) # cap2 differentiator

--- a/Makefile
+++ b/Makefile
@@ -6,26 +6,32 @@ SHELL := /usr/bin/env bash
 deploy-local-vagrant:
 	bundle exec cap -S stage=development deploy
 
-staging-deploy:
+new-staging-deploy:
+	bundle exec cap -S stage=staging deploy
+	ssh deploy@openaustralia.org.au ls -l /srv/www/staging/releases/
+	./scripts/tag-staging.sh
+
+old-staging-deploy:
 	bundle exec cap -S stage=test deploy
 	ssh deploy@openaustralia.org.au ls -l /srv/www/staging/releases/
 	./scripts/tag-staging.sh
 
-
-production-deploy:
+old-production-deploy:
 	bundle exec cap -S stage=production deploy
 	ssh deploy@openaustralia.org.au ls -l /srv/www/production/releases/
 	./scripts/tag-prod.sh
 
-staging-parse-members:
+old-staging-parse-members:
 	bundle exec cap -S stage=test parse:members
 
-production-parse-members:
+old-production-parse-members:
 	bundle exec cap -S stage=production parse:members
 
 init-submodules:
 	git submodule update --init
 
+
+# pull in latest changes from submodules
 update-twfy:
 	cd twfy && git checkout main && git pull origin main
 	git status


### PR DESCRIPTION
## Relevant issue(s)
We have changes in flux right now to get to new OS/server.

## What does this do?

- renames production-deploy to old-production-deploy which is `main` branch to old server
- renames staging-deploy to old-staging-deploy, which is `main` branch to old server
- add new-staging-deploy , which is `staging` branch to new server

## Why was this needed?
To deploy new php8 TWFY


ALSO: Update githubmodules to point to latest in `staging` branch on TWFY (we need to do this often as we're working on that PHP app)


needs https://github.com/openaustralia/infrastructure/pull/346