### PR TITLE
allow ed25519 keys for staging deploys

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -59,7 +59,7 @@ require "bundler/capistrano"
 namespace :bundler do
 	task :install do
 		# install ruby version from .ruby-version
-		run "cd #{release_path} && rbenv install -s $(cat .ruby-version)"
+		run "cd #{release_path} && /home/deploy/.rbenv/bin/rbenv install -s $(cat .ruby-version)"
 		# install bundler if it's not already installed
 		run "cd #{release_path} && gem list bundler -i || gem install bundler --no-ri --no-rdoc"
 	end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source 'https://rubygems.org'
 
+# needed for capistrano to work with ed25519 ssh keys
+gem 'ed25519', '>= 1.2', '< 2.0'
+gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
+
 gem 'capistrano', '~> 2'
 gem 'capistrano_colors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    bcrypt_pbkdf (1.1.2)
     capistrano (2.15.11)
       highline
       net-scp (>= 1.0.0)
@@ -8,6 +9,7 @@ GEM
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
     capistrano_colors (0.5.5)
+    ed25519 (1.4.0)
     highline (3.1.2)
       reline
     io-console (0.8.1)
@@ -25,8 +27,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt_pbkdf (>= 1.0, < 2.0)
   capistrano (~> 2)
   capistrano_colors
+  ed25519 (>= 1.2, < 2.0)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
## Relevant issue(s)
Need to deploy to new machines

## What does this do?
fixes capistrano to deploy to the new machine

## Why was this needed?
so we can test the new php8 version of TWFY

