### PR TITLE
Add extra gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,45 @@ provisioning/development.retry
 ubuntu-xenial-16.04-cloudimg-console.log
 ref/*
 html_cache/*
-.vscode
 vendor/**
+
+# Bundler & Dependencies
+/.bundle
+
+# IDEs and vim
+/.vscode
+/.aider*
+/.idea
+*~
+*.swp
+*.swo
+
+# Ignore patch files
+*.patch
+*.rej
+
+# Ignore all logfiles
+log/*.log
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# Used by direnv and dotenv
+.envrc
+.env
+.env.local
+.env.*.local
+
+# test coverage reports
+/coverage
+
+# Temp files
+*.bak
+/tmp/
+
+# rspec reports
+/.rspec_status
+/spec/examples.txt
+
+# Mac Finder
+.DS_Store


### PR DESCRIPTION
## Relevant issue(s)

N/A

## What does this do?

Adds extra rules in gitignore that I find useful and assume are there (eg that log/*.log is ignored)

## Why was this needed?

Primarily because I use RubyMine, vim, sometimes patch, dotenv

I like a consistent list across projects 

## Implementation/Deploy Steps (Optional)

Pull repo

