### PR TITLE
upgrading to capistrano 3

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,129 +1,117 @@
-# Capistrano 2.x recipe file
-#
-# Requirement cap 2.2
-#
-# Execute with:
-# cap -S stage=<production|test> task
+# Capistrano 3.x Capfile
+require 'capistrano/setup'
+require 'capistrano/deploy'
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
+require 'capistrano/bundler'
+require 'capistrano/rbenv'
 
-set :application, "openaustralia.org"
-
-# default_run_options[:pty] = true
-
-set :use_sudo, false
-
-# Ensure SSH uses login shell to properly set PATH
-default_run_options[:shell] = '/bin/bash -l'
-
-set :scm, :git
-set :repository, "https://github.com/openaustralia/openaustralia.git"
-set :git, "/usr/bin/git"  # Explicitly set git path for staging server
-set :git_enable_submodules, true
-set :deploy_via, :remote_cache
-
-raise "Stage not specified" unless exists? :stage
-
-set :user, "deploy"
-
-# A great little trick I learned recently. If you have a machine running on a non-standard ssh port
-# put the following in your ~/.ssh/config file:
-# Host myserver.com
-#   Port 1234
-# This will change the port for all ssh commands on that server which saves a whole lot of typing
-
-case stage
-when "staging"
-	role :web, "staging.openaustralia.org.au"
-	set :deploy_to, "/srv/www/staging"
-	set :branch, "staging"
-# when "production-new"
-# 	role :web, "staging.openaustralia.org.au" # TODO: Change this once DNS points to the new server
-# 	set :deploy_to, "/srv/www/production"
-# 	set :branch, "staging"
-when "production"
-	role :web, "openaustralia.org.au"
-	set :deploy_to, "/srv/www/production"
-	set :branch, "main"
-when "test"
-	role :web, "openaustralia.org.au"
-	set :deploy_to, "/srv/www/staging"
-	set :branch, "main"
-when "development"
-	role :web, "openaustralia.org.au.test"
-	set :deploy_to, "/srv/www/production"
-	# Uses the user's current branch
-end
-
-set :bundle_gemfile, "openaustralia-parser/Gemfile"
-
-load 'deploy' if respond_to?(:namespace) # cap2 differentiator
-
-require "bundler/capistrano"
-
-# install the bundler gem if it's not already installed
-namespace :bundler do
-	task :install do
-		# install ruby version from .ruby-version
-		run "cd #{release_path} && rbenv install -s $(cat .ruby-version)"
-		# install bundler if it's not already installed
-		run "cd #{release_path} && gem list bundler -i || gem install bundler --no-ri --no-rdoc"
-	end
-end
-
-before "bundle:install", "bundler:install"
-
-# Clean up old releases so we don't fill up our disk
-after "deploy:restart", "deploy:cleanup"
+# Load custom tasks
+Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
 
 namespace :deploy do
-	# Restart Apache because for some reason a deploy can cause trouble very occasionally (which is fixed by a restart). So, playing safe
-	task :restart do
-		sudo "apache2ctl restart"
-	end
+  desc 'Checkout code to release directory'
+  task :checkout do
+    on roles(:all) do
+      cached_copy = "#{shared_path}/cached-copy"
+      
+      # Clone or fetch repo
+      if test("[ -d #{cached_copy} ]")
+        within cached_copy do
+          execute :git, 'fetch', 'origin'
+          execute :git, 'reset', '--hard', "origin/#{fetch(:branch)}"
+          execute :git, 'clean', '-d', '-x', '-f'
+        end
+      else
+        execute :git, 'clone', '--branch', fetch(:branch), fetch(:repo_url), cached_copy
+        within cached_copy do
+          execute :git, 'reset', '--hard', "origin/#{fetch(:branch)}"
+          execute :git, 'clean', '-d', '-x', '-f'
+        end
+      end
+      
+      # Update submodules
+      within cached_copy do
+        execute :git, 'submodule', 'init'
+        execute :git, 'submodule', 'update', '--recursive'
+      end
+      
+      # Copy to release directory
+      execute :cp, '-PR', cached_copy, release_path
+    end
+  end
 
-	task :finalize_update do
-		run "chmod -R g+w #{latest_release}" if fetch(:group_writable, true)
-	end
+  desc 'Create symlinks to shared directories'
+  task :symlink_shared do
+    on roles(:all) do
+      links = {
+        'searchdb' => '../../../shared/searchdb',
+        'openaustralia-parser/configuration.yml' => '../../../../shared/parser_configuration.yml',
+        'twfy/conf/general' => '../../../../../shared/general',
+        'twfy/scripts/alerts-lastsent' => '../../../../../shared/alerts-lastsent',
+        'twfy/www/docs/sitemap.xml' => '../../../../../../shared/sitemap.xml',
+        'twfy/www/docs/sitemaps' => '../../../../../../shared/sitemaps',
+        'twfy/www/docs/images/mps' => '../../../../../../../shared/images/mps',
+        'twfy/www/docs/images/mpsL' => '../../../../../../../shared/images/mpsL',
+        'twfy/www/docs/images/mpsXL' => '../../../../../../../shared/images/mpsXL',
+        'twfy/www/docs/regmem/scan' => '../../../../../../../shared/regmem_scan',
+        'twfy/www/docs/rss/mp' => '../../../../../../../shared/rss/mp',
+        'twfy/www/docs/debates/debates.rss' => '../../../../../../../shared/rss/senate.rss',
+        'twfy/www/docs/senate/senate.rss' => '../../../../../../../shared/rss/senate.rss'
+      }
+      
+      within release_path do
+        # Copy checked-in images to shared area
+        execute :bash, '-c', "cp twfy/www/docs/images/mps/* #{shared_path}/images/mps 2>/dev/null || true"
+        execute :bash, '-c', "cp twfy/www/docs/images/mpsL/* #{shared_path}/images/mpsL 2>/dev/null || true"
+        
+        # Remove directories with checked-in files
+        execute :rm, '-rf', 'twfy/www/docs/images/mps', 'twfy/www/docs/images/mpsL', 'twfy/www/docs/rss/mp', '||', 'true'
+        
+        # Create symlinks
+        links.each do |from, to|
+          execute :bash, '-c', "ln -sf #{to} #{from} || true"
+        end
+      end
+    end
+  end
 
-	desc "After a code update, we link the images directories to the shared ones"
-	after "deploy:update_code" do
-		links = {
-			"#{release_path}/searchdb"                                => "../../shared/searchdb",
+  desc 'Compile run-with-lockfile'
+  task :compile_lockfile do
+    on roles(:all) do
+      execute :gcc, '-o', "#{release_path}/twfy/scripts/run-with-lockfile", "#{release_path}/twfy/scripts/run-with-lockfile.c"
+    end
+  end
 
-			"#{release_path}/openaustralia-parser/configuration.yml"  => "../../../shared/parser_configuration.yml",
+  desc 'Restart Apache'
+  task :restart do
+    on roles(:web) do
+      execute :sudo, '/usr/sbin/apache2ctl', 'restart'
+    end
+  end
 
-			"#{release_path}/twfy/conf/general"                       => "../../../../shared/general",
-			"#{release_path}/twfy/scripts/alerts-lastsent"            => "../../../../shared/alerts-lastsent",
-
-			"#{release_path}/twfy/www/docs/sitemap.xml"               => "../../../../../shared/sitemap.xml",
-			"#{release_path}/twfy/www/docs/sitemaps"                  => "../../../../../shared/sitemaps",
-
-			"#{release_path}/twfy/www/docs/images/mps"                => "../../../../../../shared/images/mps",
-			"#{release_path}/twfy/www/docs/images/mpsL"               => "../../../../../../shared/images/mpsL",
-			"#{release_path}/twfy/www/docs/images/mpsXL"              => "../../../../../../shared/images/mpsXL",
-			"#{release_path}/twfy/www/docs/regmem/scan"               => "../../../../../../shared/regmem_scan",
-			"#{release_path}/twfy/www/docs/rss/mp"                    => "../../../../../../shared/rss/mp",
-			"#{release_path}/twfy/www/docs/debates/debates.rss"       => "../../../../../../shared/rss/senate.rss",
-			"#{release_path}/twfy/www/docs/senate/senate.rss"       => "../../../../../../shared/rss/senate.rss"
-		}
-		# First copy any images that have been checked into the repository to the shared area
-		run "cp #{release_path}/twfy/www/docs/images/mps/* #{shared_path}/images/mps"
-		run "cp #{release_path}/twfy/www/docs/images/mpsL/* #{shared_path}/images/mpsL"
-		# HACK: Remove directories next because they have files in them
-		run "rm -rf #{release_path}/twfy/www/docs/images/mps #{release_path}/twfy/www/docs/images/mpsL #{release_path}/twfy/www/docs/rss/mp"
-		# "ln -sf <a> <b>" creates a symbolic link but deletes <b> if it already exists
-		run links.map {|a| "ln -sf #{a.last} #{a.first}"}.join(";")
-		# Now compile twfy/scripts/run-with-lockfile.c
-		run "gcc -o #{release_path}/twfy/scripts/run-with-lockfile #{release_path}/twfy/scripts/run-with-lockfile.c"
-	end
-
-	task :setup_db do
-		run "mysql < #{current_path}/twfy/db/schema.sql"
-	end
+  task :setup_db do
+    on roles(:db) do
+      within current_path do
+        execute :mysql, '<', "#{current_path}/twfy/db/schema.sql"
+      end
+    end
+  end
 end
 
+# Deploy hooks
+after 'deploy:new_release_path', 'deploy:checkout'
+after 'deploy:checkout', 'deploy:symlink_shared'
+after 'deploy:symlink_shared', 'deploy:compile_lockfile'
+after 'deploy:published', 'deploy:restart'
+
 namespace :parse do
-	desc 'Parses data about MPs & Senators and loads it into OpenAustralia'
-	task :members do
-		run "cd #{current_path}/openaustralia-parser && bundle exec parse-members.rb"
-	end
+  desc 'Parse member data and load into OpenAustralia'
+  task :members do
+    on roles(:app) do
+      within release_path do
+        execute :bash, '-c', 'cd openaustralia-parser && bundle exec parse-members.rb'
+      end
+    end
+  end
 end

--- a/Capfile
+++ b/Capfile
@@ -9,38 +9,37 @@ require 'capistrano/rbenv'
 # Load custom tasks
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
 
-namespace :deploy do
-  desc 'Checkout code to release directory'
-  task :checkout do
+# Override git:create_release to use a cached working copy with submodules
+# instead of git archive which doesn't include submodule content
+namespace :git do
+  task :create_release do
     on roles(:all) do
       cached_copy = "#{shared_path}/cached-copy"
-      
-      # Clone or fetch repo
-      if test("[ -d #{cached_copy} ]")
+
+      if test("[ -d #{cached_copy}/.git ]")
         within cached_copy do
           execute :git, 'fetch', 'origin'
           execute :git, 'reset', '--hard', "origin/#{fetch(:branch)}"
           execute :git, 'clean', '-d', '-x', '-f'
+          execute :git, 'submodule', 'init'
+          execute :git, 'submodule', 'update', '--recursive'
         end
       else
         execute :git, 'clone', '--branch', fetch(:branch), fetch(:repo_url), cached_copy
         within cached_copy do
-          execute :git, 'reset', '--hard', "origin/#{fetch(:branch)}"
-          execute :git, 'clean', '-d', '-x', '-f'
+          execute :git, 'submodule', 'init'
+          execute :git, 'submodule', 'update', '--recursive'
         end
       end
-      
-      # Update submodules
-      within cached_copy do
-        execute :git, 'submodule', 'init'
-        execute :git, 'submodule', 'update', '--recursive'
-      end
-      
-      # Copy to release directory
-      execute :cp, '-PR', cached_copy, release_path
+
+      # Copy contents (not the directory itself) to release path
+      execute :mkdir, '-p', release_path
+      execute :cp, '-a', "#{cached_copy}/.", "#{release_path}/"
     end
   end
+end
 
+namespace :deploy do
   desc 'Create symlinks to shared directories'
   task :symlink_shared do
     on roles(:all) do
@@ -59,18 +58,18 @@ namespace :deploy do
         'twfy/www/docs/debates/debates.rss' => '../../../../../../../shared/rss/senate.rss',
         'twfy/www/docs/senate/senate.rss' => '../../../../../../../shared/rss/senate.rss'
       }
-      
+
       within release_path do
         # Copy checked-in images to shared area
-        execute :bash, '-c', "cp twfy/www/docs/images/mps/* #{shared_path}/images/mps 2>/dev/null || true"
-        execute :bash, '-c', "cp twfy/www/docs/images/mpsL/* #{shared_path}/images/mpsL 2>/dev/null || true"
-        
-        # Remove directories with checked-in files
-        execute :rm, '-rf', 'twfy/www/docs/images/mps', 'twfy/www/docs/images/mpsL', 'twfy/www/docs/rss/mp', '||', 'true'
-        
+        execute :bash, '-c', "'cp twfy/www/docs/images/mps/* #{shared_path}/images/mps 2>/dev/null || true'"
+        execute :bash, '-c', "'cp twfy/www/docs/images/mpsL/* #{shared_path}/images/mpsL 2>/dev/null || true'"
+
+        # Remove directories with checked-in files before symlinking
+        execute :bash, '-c', "'rm -rf twfy/www/docs/images/mps twfy/www/docs/images/mpsL twfy/www/docs/rss/mp'"
+
         # Create symlinks
         links.each do |from, to|
-          execute :bash, '-c', "ln -sf #{to} #{from} || true"
+          execute :ln, '-sf', to, from
         end
       end
     end
@@ -79,7 +78,9 @@ namespace :deploy do
   desc 'Compile run-with-lockfile'
   task :compile_lockfile do
     on roles(:all) do
-      execute :gcc, '-o', "#{release_path}/twfy/scripts/run-with-lockfile", "#{release_path}/twfy/scripts/run-with-lockfile.c"
+      within release_path do
+        execute :gcc, '-o', 'twfy/scripts/run-with-lockfile', 'twfy/scripts/run-with-lockfile.c'
+      end
     end
   end
 
@@ -93,15 +94,13 @@ namespace :deploy do
   task :setup_db do
     on roles(:db) do
       within current_path do
-        execute :mysql, '<', "#{current_path}/twfy/db/schema.sql"
+        execute :bash, '-c', "mysql < #{current_path}/twfy/db/schema.sql"
       end
     end
   end
 end
 
-# Deploy hooks
-after 'deploy:new_release_path', 'deploy:checkout'
-after 'deploy:checkout', 'deploy:symlink_shared'
+after 'git:create_release', 'deploy:symlink_shared'
 after 'deploy:symlink_shared', 'deploy:compile_lockfile'
 after 'deploy:published', 'deploy:restart'
 
@@ -109,7 +108,7 @@ namespace :parse do
   desc 'Parse member data and load into OpenAustralia'
   task :members do
     on roles(:app) do
-      within release_path do
+      within current_path do
         execute :bash, '-c', 'cd openaustralia-parser && bundle exec parse-members.rb'
       end
     end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'capistrano', '~> 2'
-gem 'capistrano_colors'
+gem 'capistrano', '~> 3.17'
+gem 'capistrano-bundler'
+gem 'capistrano-rbenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,45 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    capistrano (2.15.11)
-      highline
-      net-scp (>= 1.0.0)
-      net-sftp (>= 2.0.0)
-      net-ssh (>= 2.0.14)
-      net-ssh-gateway (>= 1.1.0)
-    capistrano_colors (0.5.5)
-    highline (3.1.2)
-      reline
-    io-console (0.8.1)
+    airbrussh (1.6.1)
+      sshkit (>= 1.6.1, != 1.7.0)
+    base64 (0.3.0)
+    capistrano (3.20.0)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundler (2.2.0)
+      capistrano (~> 3.1)
+    capistrano-rbenv (2.2.0)
+      capistrano (~> 3.1)
+      sshkit (~> 1.3)
+    concurrent-ruby (1.3.6)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    logger (1.7.0)
     net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.3.0)
-    net-ssh-gateway (2.0.0)
-      net-ssh (>= 4.0.0)
-    reline (0.6.2)
-      io-console (~> 0.5)
+    ostruct (0.6.3)
+    rake (13.3.1)
+    sshkit (1.25.0)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  capistrano (~> 2)
-  capistrano_colors
+  capistrano (~> 3.17)
+  capistrano-bundler
+  capistrano-rbenv
 
 BUNDLED WITH
    2.1.4

--- a/Makefile
+++ b/Makefile
@@ -10,25 +10,22 @@ deploy-local-vagrant:
 	bundle exec cap -S stage=development deploy
 
 new-staging-deploy:
-	bundle exec cap -S stage=staging deploy
+	bundle exec cap staging deploy
 	ssh deploy@staging.openaustralia.org.au ls -l /srv/www/staging/releases/
-	./scripts/tag-staging.sh
 
 old-staging-deploy:
-	bundle exec cap -S stage=test deploy
-	ssh deploy@openaustralia.org.au ls -l /srv/www/staging/releases/
-	./scripts/tag-staging.sh
+	bundle exec cap staging deploy
+	ssh deploy@staging.openaustralia.org.au ls -l /srv/www/staging/releases/
 
 old-production-deploy:
-	bundle exec cap -S stage=production deploy
+	bundle exec cap production deploy
 	ssh deploy@openaustralia.org.au ls -l /srv/www/production/releases/
-	./scripts/tag-prod.sh
 
 old-staging-parse-members:
-	bundle exec cap -S stage=test parse:members
+	bundle exec cap staging parse:members
 
 old-production-parse-members:
-	bundle exec cap -S stage=production parse:members
+	bundle exec cap production parse:members
 
 init-submodules:
 	git submodule update --init

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,31 @@
+# Common Capistrano 3 configuration
+set :application, 'openaustralia.org'
+set :repo_url, 'https://github.com/openaustralia/openaustralia.git'
+set :deploy_via, :remote_cache
+
+# Ruby/rbenv configuration
+set :rbenv_type, :user
+set :rbenv_ruby, File.read('.ruby-version').strip
+
+# Bundler configuration
+set :bundle_gemfile, 'openaustralia-parser/Gemfile'
+set :bundle_roles, :app
+set :bundle_flags, '--deployment'
+
+# Use sudo for apache restart
+set :use_sudo, true
+
+# Keep last 5 releases
+set :keep_releases, 5
+
+# SSH options
+set :ssh_options, {
+  forward_agent: true,
+  user: 'deploy',
+  keys: %w[~/.ssh/id_rsa],
+  verify_host_key: :accept_new_or_local_tunnel,
+  verbose: :info
+}
+
+# Load stage-specific configuration
+load "#{__dir__}/deploy/#{fetch(:stage, 'staging')}.rb"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :ssh_options, {
   user: 'deploy',
   keys: %w[~/.ssh/id_rsa],
   verify_host_key: :accept_new_or_local_tunnel,
-  verbose: :info
+  # verbose: :info
 }
 
 # Load stage-specific configuration

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,3 +1,5 @@
+# FOR SAFETY this is commented out until we have approved the staging deployment
+# this prevents accidental deployment to production
 # server 'openaustralia.org.au', user: 'deploy', roles: %w[app web], primary: true
 
 # set :deploy_to, '/srv/www/production'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,0 +1,4 @@
+# server 'openaustralia.org.au', user: 'deploy', roles: %w[app web], primary: true
+
+# set :deploy_to, '/srv/www/production'
+# set :branch, 'main'

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,0 +1,4 @@
+server 'staging.openaustralia.org.au', user: 'deploy', roles: %w[app web], primary: true
+
+set :deploy_to, '/srv/www/staging'
+set :branch, 'staging'


### PR DESCRIPTION
## Relevant issue(s)
capistano 3 was released in 2013. It's time we upgraded too.

## What does this do?
convert our 2008 era capistrano to be more like 2020.

## Why was this needed?
Various parts of the deploy are failing on the new Ubuntu LTS target, and this was a better way forward than fixing those.