### PR TITLE
Use parser's bin/run to run any of its scripts

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -109,7 +109,7 @@ namespace :parse do
   task :members do
     on roles(:app) do
       within current_path do
-        execute :bash, '-c', 'cd openaustralia-parser && bundle exec parse-members.rb'
+        execute :bash, '-c', 'openaustralia-parser/bin/run parse-members.rb'
       end
     end
   end

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ daily:
 	cd twfy/scripts && ./dailyupdate
 
 parse-members:
-	cd openaustralia-parser && bundle exec parse-member-links.rb
+	openaustralia-parser/bin/run parse-member-links.rb


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Decouples wha its used to run what  parser's bin/run does what parser needs, we don't need to know or control

## Why was this needed?

* This repo was running parser's code with this repos ruby version and Gemfile

## Implementation/Deploy Steps (Optional)

Update submodules for openaustralia

## Notes to reviewer (Optional)
