### PR TITLE
Ignore the main branches submodule directories, not just the files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ shlib/*
 twfy/*
 pwdata/*
 html_cache/*
+
+/openaustralia-parser
+/perllib
+/phplib
+/rblib
+/shlib
+/twfy


### PR DESCRIPTION
## Relevant issue(s)

N/A

## What does this do?

Stops git suggesting the submodule dirs are not committed when you swap between other and gh-pages related branches

## Why was this needed?

Stops accidentally committing submodule dirs into gh-pages.
Fixed when I noticed it

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
