### PR TITLE
Add the same ruby version enforcement as parser has

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby file: ".ruby-version"
+
 gem 'capistrano', '~> 3.17'
 gem 'capistrano-bundler'
 gem 'capistrano-rbenv'


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Makes sure the correct ruby version is being used

## Why was this needed?

For clarity when fixing issues, rather than code being run by a different than expected version with possibly different gems installed than bundler installed on the correct version.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
