### PR TITLE
Use shared_path rather than relative links

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -14,7 +14,7 @@ Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
 namespace :git do
   task :create_release do
     on roles(:all) do
-      cached_copy = "#{shared_path}/cached-copy"
+      cached_copy = "#{fetch(:shared_path)}/cached-copy"
 
       if test("[ -d #{cached_copy}/.git ]")
         within cached_copy do
@@ -44,25 +44,25 @@ namespace :deploy do
   task :symlink_shared do
     on roles(:all) do
       links = {
-        'searchdb' => '../shared/search/searchdb',
-        'openaustralia-parser/configuration.yml' => '../../../shared/parser_configuration.yml',
-        'twfy/conf/general' => '../../../../shared/general',
-        'twfy/scripts/alerts-lastsent' => '../../../../shared/alerts-lastsent',
-        'twfy/www/docs/sitemap.xml' => '../../../../../shared/sitemap.xml',
-        'twfy/www/docs/sitemaps' => '../../../../../shared/sitemaps',
-        'twfy/www/docs/images/mps' => '../../../../../../shared/images/mps',
-        'twfy/www/docs/images/mpsL' => '../../../../../../shared/images/mpsL',
-        'twfy/www/docs/images/mpsXL' => '../../../../../../shared/images/mpsXL',
-        'twfy/www/docs/regmem/scan' => '../../../../../../shared/regmem_scan',
-        'twfy/www/docs/rss/mp' => '../../../../../../shared/rss/mp',
-        'twfy/www/docs/debates/debates.rss' => '../../../../../../shared/rss/senate.rss',
-        'twfy/www/docs/senate/senate.rss' => '../../../../../../shared/rss/senate.rss'
+        'searchdb' => "#{fetch(:shared_path)}/shared/search/searchdb",
+        'openaustralia-parser/configuration.yml' => "#{fetch(:shared_path)}/parser_configuration.yml",
+        'twfy/conf/general' => "#{fetch(:shared_path)}/general",
+        'twfy/scripts/alerts-lastsent' => "#{fetch(:shared_path)}/alerts-lastsent",
+        'twfy/www/docs/sitemap.xml' => "#{fetch(:shared_path)}/sitemap.xml",
+        'twfy/www/docs/sitemaps' => "#{fetch(:shared_path)}/sitemaps",
+        'twfy/www/docs/images/mps' => "#{fetch(:shared_path)}/images/mps",
+        'twfy/www/docs/images/mpsL' => "#{fetch(:shared_path)}/images/mpsL",
+        'twfy/www/docs/images/mpsXL' => "#{fetch(:shared_path)}/images/mpsXL",
+        'twfy/www/docs/regmem/scan' => "#{fetch(:shared_path)}/regmem_scan",
+        'twfy/www/docs/rss/mp' => "#{fetch(:shared_path)}/rss/mp",
+        'twfy/www/docs/debates/debates.rss' => "#{fetch(:shared_path)}/rss/senate.rss",
+        'twfy/www/docs/senate/senate.rss' => "#{fetch(:shared_path)}/rss/senate.rss"
       }
 
       within release_path do
         # Copy checked-in images to shared area
-        execute :bash, '-c', "'cp twfy/www/docs/images/mps/* #{shared_path}/images/mps 2>/dev/null || true'"
-        execute :bash, '-c', "'cp twfy/www/docs/images/mpsL/* #{shared_path}/images/mpsL 2>/dev/null || true'"
+        execute :bash, '-c', "'cp twfy/www/docs/images/mps/* #{fetch(:shared_path)}/images/mps 2>/dev/null || true'"
+        execute :bash, '-c', "'cp twfy/www/docs/images/mpsL/* #{fetch(:shared_path)}/images/mpsL 2>/dev/null || true'"
 
         # Remove directories with checked-in files before symlinking
         execute :bash, '-c', "'rm -rf twfy/www/docs/images/mps twfy/www/docs/images/mpsL twfy/www/docs/rss/mp'"

--- a/Capfile
+++ b/Capfile
@@ -14,7 +14,7 @@ Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
 namespace :git do
   task :create_release do
     on roles(:all) do
-      cached_copy = "#{fetch(:shared_path)}/cached-copy"
+      cached_copy = "#{shared_path}/cached-copy"
 
       if test("[ -d #{cached_copy}/.git ]")
         within cached_copy do
@@ -44,25 +44,25 @@ namespace :deploy do
   task :symlink_shared do
     on roles(:all) do
       links = {
-        'searchdb' => "#{fetch(:shared_path)}/shared/search/searchdb",
-        'openaustralia-parser/configuration.yml' => "#{fetch(:shared_path)}/parser_configuration.yml",
-        'twfy/conf/general' => "#{fetch(:shared_path)}/general",
-        'twfy/scripts/alerts-lastsent' => "#{fetch(:shared_path)}/alerts-lastsent",
-        'twfy/www/docs/sitemap.xml' => "#{fetch(:shared_path)}/sitemap.xml",
-        'twfy/www/docs/sitemaps' => "#{fetch(:shared_path)}/sitemaps",
-        'twfy/www/docs/images/mps' => "#{fetch(:shared_path)}/images/mps",
-        'twfy/www/docs/images/mpsL' => "#{fetch(:shared_path)}/images/mpsL",
-        'twfy/www/docs/images/mpsXL' => "#{fetch(:shared_path)}/images/mpsXL",
-        'twfy/www/docs/regmem/scan' => "#{fetch(:shared_path)}/regmem_scan",
-        'twfy/www/docs/rss/mp' => "#{fetch(:shared_path)}/rss/mp",
-        'twfy/www/docs/debates/debates.rss' => "#{fetch(:shared_path)}/rss/senate.rss",
-        'twfy/www/docs/senate/senate.rss' => "#{fetch(:shared_path)}/rss/senate.rss"
+        'searchdb' => "#{shared_path}/shared/search/searchdb",
+        'openaustralia-parser/configuration.yml' => "#{shared_path}/parser_configuration.yml",
+        'twfy/conf/general' => "#{shared_path}/general",
+        'twfy/scripts/alerts-lastsent' => "#{shared_path}/alerts-lastsent",
+        'twfy/www/docs/sitemap.xml' => "#{shared_path}/sitemap.xml",
+        'twfy/www/docs/sitemaps' => "#{shared_path}/sitemaps",
+        'twfy/www/docs/images/mps' => "#{shared_path}/images/mps",
+        'twfy/www/docs/images/mpsL' => "#{shared_path}/images/mpsL",
+        'twfy/www/docs/images/mpsXL' => "#{shared_path}/images/mpsXL",
+        'twfy/www/docs/regmem/scan' => "#{shared_path}/regmem_scan",
+        'twfy/www/docs/rss/mp' => "#{shared_path}/rss/mp",
+        'twfy/www/docs/debates/debates.rss' => "#{shared_path}/rss/senate.rss",
+        'twfy/www/docs/senate/senate.rss' => "#{shared_path}/rss/senate.rss"
       }
 
       within release_path do
         # Copy checked-in images to shared area
-        execute :bash, '-c', "'cp twfy/www/docs/images/mps/* #{fetch(:shared_path)}/images/mps 2>/dev/null || true'"
-        execute :bash, '-c', "'cp twfy/www/docs/images/mpsL/* #{fetch(:shared_path)}/images/mpsL 2>/dev/null || true'"
+        execute :bash, '-c', "'cp twfy/www/docs/images/mps/* #{shared_path}/images/mps 2>/dev/null || true'"
+        execute :bash, '-c', "'cp twfy/www/docs/images/mpsL/* #{shared_path}/images/mpsL 2>/dev/null || true'"
 
         # Remove directories with checked-in files before symlinking
         execute :bash, '-c', "'rm -rf twfy/www/docs/images/mps twfy/www/docs/images/mpsL twfy/www/docs/rss/mp'"


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Uses Absolute rather than relative symlinks, which is highly recommended when you are in a directory symlinked from a different depth.

Fixes the fix:
* https://github.com/openaustralia/openaustralia/pull/761

## Why was this needed?

This is important because 
1. .../current is a symlink to .../releases/TIMESTAMP which is at a different depth, so relative symlinks can't work in both places. 
2. bash and ruby wont work at the same time with relative symlinks because they have a different concept of the current directory when "in the current dir"
3. capistrano configures releases whilst in releases/NNNN and only symlinks that to current at the last moment, so relative symlinks can also break capsitrano setup.

```
deploy@ip-172-31-43-242:/srv/www/production/current$ pwd -P
/srv/www/production/releases/20260327041730
deploy@ip-172-31-43-242:/srv/www/production/current$ pwd
/srv/www/production/current
deploy@ip-172-31-43-242:/srv/www/production/current$ irb
3.1.7 :001 > Dir.pwd 
 => "/srv/www/production/releases/20260327041730" 
3.1.7 :002 > 

deploy@ip-172-31-43-242:/srv/www/production/current$ /bin/sh 
$ pwd
/srv/www/production/current
# This was a surprise to me - last decade / century sh and bash reported different pwd
```

## Alternatives:

Considered refactoring to the more recent use of linked_files and linked_dirs, but was unsure if this would cause more grief than it was worth, given the shared dirs are not a 1:1 mapping.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

Deployed to staging and checked and it works (wc -c for files, du -ks for dirs) - some targets are missing:

```
wc: searchdb: No such file or directory
wc: /srv/www/staging/shared/shared/search/searchdb: No such file or directory
2015 openaustralia-parser/configuration.yml
2015 /srv/www/staging/shared/parser_configuration.yml
5713 twfy/conf/general
5713 /srv/www/staging/shared/general
wc: twfy/scripts/alerts-lastsent: No such file or directory
wc: /srv/www/staging/shared/alerts-lastsent: No such file or directory
wc: twfy/www/docs/sitemap.xml: No such file or directory
wc: /srv/www/staging/shared/sitemap.xml: No such file or directory
0	twfy/www/docs/sitemaps
4	/srv/www/staging/shared/sitemaps
0	twfy/www/docs/images/mps
72	/srv/www/staging/shared/images/mps
0	twfy/www/docs/images/mpsL
76	/srv/www/staging/shared/images/mpsL
0	twfy/www/docs/images/mpsXL
4	/srv/www/staging/shared/images/mpsXL
0	twfy/www/docs/regmem/scan
0	/srv/www/staging/shared/regmem_scan
0	twfy/www/docs/rss/mp
4	/srv/www/staging/shared/rss/mp
wc: twfy/www/docs/debates/debates.rss: No such file or directory
wc: /srv/www/staging/shared/rss/senate.rss: No such file or directory
wc: twfy/www/docs/senate/senate.rss: No such file or directory
wc: /srv/www/staging/shared/rss/senate.rss: No such file or directory
```
