### PR TITLE
Use openaustralia-parser/.ruby-version for deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
+# This Gemfile is used ONLY for deployment and other dev tools
+# Capistrano configures the destination server with openaustralia-parser/Gemfile and openaustralia-parser/.ruby-version
+
 source 'https://rubygems.org'
 
 gem 'capistrano', '~> 3.17'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ set :deploy_via, :remote_cache
 
 # Ruby/rbenv configuration
 set :rbenv_type, :user
-set :rbenv_ruby, File.read('.ruby-version').strip
+set :rbenv_ruby, File.read('openaustralia-parser/.ruby-version').strip
 
 # Bundler configuration
 set :bundle_gemfile, 'openaustralia-parser/Gemfile'


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Use openaustralia-parser/.ruby-version for deployment since we use its Gemfile

## Why was this needed?

It makes no sense to use the parsers Gemfile to install gems without doing it on the ruby version that the Gemfile is associated with. The base Gemfile is only used (AFAIK) on dev systems to run capistrano.

This keeps them in lockstep without having to keep openaustralia using the same ruby for deployment as is used on the server to run parser's scripts

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
