### PR TITLE
Output notice that deploying to production doesn't actually deploy to production!

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -4,6 +4,7 @@ require 'capistrano/deploy'
 require 'capistrano/scm/git'
 install_plugin Capistrano::SCM::Git
 require 'capistrano/bundler'
+# Check for this ruby manager first in openaustralia-parser:bin/run
 require 'capistrano/rbenv'
 
 # Load custom tasks

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The easiest way to get a development copy running is to use Vagrant, VirtualBox,
 
 Ansible doesn't currently create a `~vagrant/.my.cnf` so you'll have
 to create one by hand, pinching DB details from
-/srv/www/production/shared/config/general`.
+`/srv/www/production/shared/config/general`.
 
 Then:
 
@@ -51,12 +51,12 @@ Once the submodule change is in `main` branch on github, you're ready to deploy:
 To deploy to ([Staging](https://www.test.openaustralia.org.au/)):
 ```bash
   make staging-deploy
-  ```
+```
 
 If you've updated data about members you'll need to parse that and import it. This happens automatically once a day or you can run it using this Capistrano task:
 ```bash
   make staging-parse-members
-  ```
+```
 
 
 To deploy to ([Production](https://www.openaustralia.org.au/)):

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,6 +4,7 @@ set :repo_url, 'https://github.com/openaustralia/openaustralia.git'
 set :deploy_via, :remote_cache
 
 # Ruby/rbenv configuration
+# Check for this ruby manager first in openaustralia-parser:bin/run
 set :rbenv_type, :user
 set :rbenv_ruby, File.read('.ruby-version').strip
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,3 +1,5 @@
+puts '=' * 75, 'NOTICE: using branch: staging on server: staging.openaustralia.org.au NOT production!', '=' * 75
+
 server 'staging.openaustralia.org.au', user: 'deploy', roles: %w[app web], primary: true
 
 set :deploy_to, '/srv/www/production'


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

* Clarify when running `cap production deploy` we are NOT actually deploying to production currently!
* Note cross dependency of capistranos ruby manager setup and bin/run check order 

## Why was this needed?

[Norman doors](https://en.wikipedia.org/wiki/The_Design_of_Everyday_Things) cause confusion! This PR applies the common "Slap a sign on it" attempted fix!

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

This is a quick fix, rather than addressing the underlying issue - things should always do what they say on the packet, not something surprising! When you eventually revert to what they should do, you then have to unlearn that you issue the command to deploy to production when you mean to deploy to staging!