### PR TITLE
Feature/add capistrano tagging

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,6 +5,7 @@ require 'capistrano/scm/git'
 install_plugin Capistrano::SCM::Git
 require 'capistrano/bundler'
 require 'capistrano/rbenv'
+require 'capistrano/tagging3'
 
 # Load custom tasks
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 gem 'capistrano', '~> 3.17'
 gem 'capistrano-bundler'
 gem 'capistrano-rbenv'
+gem "capistrano-tagging3", "~> 2.0"
+
 # needed for capistrano to work with ed25519 ssh keys
 gem 'ed25519', '>= 1.2', '< 2.0'
 gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,8 @@ GEM
     capistrano-rbenv (2.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
+    capistrano-tagging3 (2.0.0)
+      capistrano (~> 3.0)
     concurrent-ruby (1.3.6)
     ed25519 (1.4.0)
     i18n (1.14.8)
@@ -44,6 +46,7 @@ DEPENDENCIES
   capistrano (~> 3.17)
   capistrano-bundler
   capistrano-rbenv
+  capistrano-tagging3 (~> 2.0)
   ed25519 (>= 1.2, < 2.0)
 
 CHECKSUMS
@@ -53,6 +56,7 @@ CHECKSUMS
   capistrano (3.20.0) sha256=0113e58dda99add0342e56a244f664734c59f442c5ed734f5303b0b559b479c9
   capistrano-bundler (2.2.0) sha256=47b4cf2ea17ea132bb0a5cabc5663443f5190a54f4da5b322d04e1558ff1468c
   capistrano-rbenv (2.2.0) sha256=3c8f39b7c624f3806630dcb475484bb3579aef07a40efe85089d83f64b0c35f5
+  capistrano-tagging3 (2.0.0) sha256=cf676c5c8928bbcb59dda4b75dcf9bb096d5f4ae5641a1b5a5ac5ddbb3e136b3
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -29,3 +29,6 @@ set :ssh_options, {
 
 # Load stage-specific configuration
 load "#{__dir__}/deploy/#{fetch(:stage, 'staging')}.rb"
+
+# Tagging options
+set :tagging3_format, ':stage_:release'


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Tags releases to staging and production when capistrano deploys with the stage name and release number (datetime)

## Why was this needed?

Clarifies what was deployed when

## Implementation/Deploy Steps (Optional)

Just use capistrano as normal

## Notes to reviewer (Optional)

This removes the need for various other scripts and wont be forgotten because it always tags each release
