### PR TITLE
Allow cap -T and other options to work without setting stage

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,4 +28,9 @@ set :ssh_options, {
 }
 
 # Load stage-specific configuration
-load "#{__dir__}/deploy/#{fetch(:stage, 'staging')}.rb"
+stage_config = File.join(__dir__, 'deploy', "#{fetch(:stage, 'staging')}.rb")
+if File.exist?(stage_config)
+  load stage_config
+else
+  puts "warning: No stage-specific configuration found for #{fetch(:stage, 'staging').inspect}!"
+end


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Allows me to run `cap -T``

## Why was this needed?

I wanted to see the cap tasks available to fix some perms issues

## Implementation/Deploy Steps (Optional)

Use cap as normal AND with all the extra options
