### PR TITLE
Make ssh key used for deployment configurable, document how, and check for ed25519 as well as rsa by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Yay, you've done it! Visit http://openaustralia.org.au.test and you should see y
 
 OpenAustralia.org is deployed using Capistrano from this repository. Once you've made changes to the web application or the parser and those have been pushed to GitHub you'll first need to update their submodules in this repository.
 
+Set `DEPLOY_SSH_KEY` ENV var if you are using a different ssh key for deployment than `~/.ssh/id_ed25519` (prefered) or `~/.ssh/id_rsa`.
+
 You do this by adding and committing, just like you would with any other change in Git. Here's what it looks like to update both the parser and the web application's submodules:
 
 ```bash

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,7 +22,7 @@ set :keep_releases, 5
 set :ssh_options, {
   forward_agent: true,
   user: 'deploy',
-  keys: %w[~/.ssh/id_rsa],
+  keys: [ENV['DEPLOY_SSH_KEY'], '~/.ssh/id_ed25519', '~/.ssh/id_rsa'].compact,
   verify_host_key: :accept_new_or_local_tunnel,
   # verbose: :info
 }


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

* Allows developer to set `DEPLOY_SSH_KEY` ENV var if they are using a different ssh key.
* Adds `~/.ssh/id_ed25519` (prefered) to the existing option of `~/.ssh/id_rsa`.
* net-ssh checks each in turn till one exists and works

## Why was this needed?

* I use an oaf specific key;
* The intent to allow keys is obvious from the change to Gemfile and the associated comment, but was being ignored because of the ssh options set.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
