### PR TITLE
Allow other staging branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ OpenAustralia.org is deployed using Capistrano from this repository. Once you've
 
 You do this by adding and committing, just like you would with any other change in Git. Here's what it looks like to update both the parser and the web application's submodules:
 
+Use `main` branch for production, or `staging` for staging. 
+You can set STAGING_BRANCH ENV var if you want a different staging branch.
+
 ```bash
   cd openaustralia
   #pull in the latest `main` branch of openaustralia-parser and twfy
@@ -48,7 +51,7 @@ That will commit the changes for you. Have a look around with `git status` then 
 
 Once the submodule change is in `main` branch on github, you're ready to deploy:
 
-To deploy to ([Staging](https://www.test.openaustralia.org.au/)):
+To deploy the STAGING_BRANCH / staging branch to ([Staging](https://www.test.openaustralia.org.au/)):
 ```bash
   make staging-deploy
   ```
@@ -59,7 +62,7 @@ If you've updated data about members you'll need to parse that and import it. Th
   ```
 
 
-To deploy to ([Production](https://www.openaustralia.org.au/)):
+To deploy the main branch to ([Production](https://www.openaustralia.org.au/)):
 ```bash
   make production-deploy
   make production-parse-members

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,4 +1,4 @@
 server 'staging.openaustralia.org.au', user: 'deploy', roles: %w[app web], primary: true
 
 set :deploy_to, '/srv/www/staging'
-set :branch, 'staging'
+set :branch, ENV.fetch('STAGING_BRANCH', 'staging')


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/741

## What does this do?

Allows multiple staging branches

## Why was this needed?

Makes it easy for multiple people to work on various release candidates and swap the staging server between branches as needed.
I wanted to delevop and deploy from ians-staging branch without changing the staging branch.

## Implementation/Deploy Steps (Optional)

Set STAGING_BRANCH ENV variable as desired. 

## Notes to reviewer (Optional)

I use `.envrc` and direnv package, for example my `.envrc` is:
```bash
export DEPLOY_SSH_KEY=~/.ssh/id_rsa_openaustralia
export STAGING_BRANCH=ians-staging
```