### PR TITLE
Add the main ignore list to gh-pages to help when you flick back and forth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,56 @@ html_cache/*
 /rblib
 /shlib
 /twfy
+
+# Ignores from main codebase ...
+
+xapiandb/*
+searchdb-lastupdated
+searchdb-previous/*
+searchdb/*
+.vagrant/
+provisioning/development.retry
+ubuntu-xenial-16.04-cloudimg-console.log
+ref/*
+vendor/**
+
+# Bundler & Dependencies
+/.bundle
+
+# IDEs and vim
+/.vscode
+/.aider*
+/.idea
+*~
+*.swp
+*.swo
+
+# Ignore patch files
+*.patch
+*.rej
+
+# Ignore all logfiles
+log/*.log
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# Used by direnv and dotenv
+.envrc
+.env
+.env.local
+.env.*.local
+
+# test coverage reports
+/coverage
+
+# Temp files
+*.bak
+/tmp/
+
+# rspec reports
+/.rspec_status
+/spec/examples.txt
+
+# Mac Finder
+.DS_Store


### PR DESCRIPTION
## Relevant issue(s)

N/A

## What does this do?

stops Untracked files leaking from maincodebase, eg
```
$ git status
On branch gh-pages
Your branch is up to date with 'origin/gh-pages'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.envrc
```

## Why was this needed?

Fixed it when I noticed it

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
