### PR TITLE
Allow override of staging branch when deploying to production on new server

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Set `DEPLOY_SSH_KEY` ENV var if you are using a different ssh key for deployment
 You do this by adding and committing, just like you would with any other change in Git. Here's what it looks like to update both the parser and the web application's submodules:
 
 Use `main` branch for production, or `staging` for staging. 
-You can set STAGING_BRANCH ENV var if you want a different staging branch.
+Whilst we are setting up a new server we changed stage=production to use staging branch, with the override below (This will be reverted).
+You can set `STAGING_BRANCH` ENV var if you want a different staging branch.
 
 ```bash
   cd openaustralia

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,6 +1,6 @@
-puts '=' * 75, 'NOTICE: using branch: staging on server: staging.openaustralia.org.au NOT production!', '=' * 75
+puts '=' * 75, "NOTICE: using branch: #{ENV.fetch('STAGING_BRANCH', 'staging')} on server: staging.openaustralia.org.au NOT production on live!", '=' * 75
 
 server 'staging.openaustralia.org.au', user: 'deploy', roles: %w[app web], primary: true
 
 set :deploy_to, '/srv/www/production'
-set :branch, 'staging'
+set :branch, ENV.fetch('STAGING_BRANCH', 'staging')


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/392

## What does this do?

Allow override of staging branch when deploying to production on new server

## Why was this needed?

Allows me to test changes whilst Brenda sleeps or does her day job (and visa versa)

I didn't want to mess with Brenda's staging branch

## Implementation/Deploy Steps (Optional)

Set STAGING_BRANCH=ians-staging (as an example) to override the branch used

## Notes to reviewer (Optional)
