### PR TITLE
Feature/788 check submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,3 +61,14 @@ update-perllib: perllib/.git
 	@echo "Checking perllib is in sync with main branch"
 	cd perllib && git fetch origin && git checkout main && git pull origin main
 	git add --patch perllib && git commit -m "Update to latest perllib"
+
+check-submodules:
+	@git submodule foreach -q 'git fetch -q origin main'
+	@behind=$$(git submodule | sed -n 's/^\([^ ]\{8\}\)[^ ]*  *\([^ ][^ ]*\) *\(.*\)/make update-\2 \t# will update to: \1 \2 \t\3/p'); \
+	  if [ -z "$$behind" ]; then \
+		count=$$(git submodule | wc -l); \
+	    echo "All $$count submodules up to date"; \
+	  else \
+	    echo "Run the following commands to update submodules:"; \
+	    echo "$$behind"; \
+	  fi

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You can set `OVERRIDE_BRANCH` ENV var if you want a different staging branch.
 
 ```bash
   cd openaustralia
+  make check-submodules # to check what has changed
   #pull in the latest `main` branch of openaustralia-parser and twfy
   make update-twfy
   make update-openaustralia-parser


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/788

## What does this do?

Adds check-submodules goal to check if submodules are up to date. If not it will output the remedial action to take, eg:

```
$ make check-submodules 
Run the following commands to update submodules:
make update-perllib 	# will update to: +54f41eb perllib 	(heads/main)
make update-rblib 	# will update to: +206eb09 rblib 	(heads/main)
make update-twfy 	# will update to: +caf26f1 twfy 	(heads/main)
```
If the submodule are up to date, it will confirm:
```
$ make check-submodules 
All 6 submodules up to date
```

## Why was this needed?

To reduce manual effort in doing this again, following https://thethreevirtues.com/

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

I donated 1/2 hour to this.