### PR TITLE
Use per environment override for the deployment branch and updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Set `DEPLOY_SSH_KEY` ENV var if you are using a different ssh key for deployment
 
 You do this by adding and committing, just like you would with any other change in Git. Here's what it looks like to update both the parser and the web application's submodules:
 
-Use `main` branch for production, or `staging` for staging. 
-Whilst we are setting up a new server we changed stage=production to use staging branch, with the override below (This will be reverted).
-You can set `OVERRIDE_BRANCH` ENV var if you want a different staging branch.
+By default the `main` branch is deployed to both production and staging. You can override this using:
+* `STAGING_BRANCH` ENV var if you want a different staging branch;
+* `PRODUCTION_BRANCH` ENV var if you want a different production branch, eg whilst setting up a new server.
 
 ```bash
   cd openaustralia

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,6 @@
 server 'openaustralia.org.au', user: 'deploy', roles: %w[app web], primary: true
 
 set :deploy_to, '/srv/www/production'
-set :branch, ENV.fetch('OVERRIDE_BRANCH', 'main')
+set :branch, ENV.fetch('PRODUCTION_BRANCH', 'main')
+
+puts '=' * 75, "NOTICE: deploying #{ENV['PRODUCTION_BRANCH']} NOT main branch to production!", '=' * 75 if ENV['PRODUCTION_BRANCH']

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,4 +1,6 @@
 server 'openaustralia.org.au', user: 'deploy', roles: %w[app web], primary: true
 
 set :deploy_to, '/srv/www/staging'
-set :branch, ENV.fetch('OVERRIDE_BRANCH', 'main')
+set :branch, ENV.fetch('STAGING_BRANCH', 'main')
+
+puts '=' * 75, "NOTICE: deploying #{ENV['STAGING_BRANCH']} NOT main branch to staging!", '=' * 75 if ENV['STAGING_BRANCH']


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/788

## What does this do?

Uses per environment override for the deployment branch and update README.md

* Reduce risk a staging branch will be deployed to production
  * now you have to explicitly set PRODUCTION_BRANCH to change production deployment
* Correct README (staging defaults to main not staging)
* Allows STAGING_BRANCH=staging to be set in .envrc without danger to production
* Cleans up description to be general not a once off incident

## Why was this needed?

1. Reduces danger of accidentality deploying the wrong branch to production
2. corrects README

## Implementation/Deploy Steps (Optional)

Follow README instructions

## Notes to reviewer (Optional)
