### PR TITLE
Add bundler cooldown period of 7 days in github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     directory: /
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Add bundler cooldown period of 7 days in github actions

Added to match theyvoteforyou
* https://github.com/openaustralia/theyvoteforyou/pull/1599

## Why was this needed?

Consistency

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)
