### PR TITLE
Fix/check submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,18 @@ update-perllib: perllib/.git
 
 check-submodules:
 	@git submodule foreach -q 'git fetch -q origin $(SUBMODULE_BRANCH)'
-	@behind=$$(git submodule | sed -n 's/^\([^ ]\{8\}\)[^ ]*  *\([^ ][^ ]*\) *\(.*\)/make update-\2 \t# will update to: \1 \2 \t\3/p'); \
+	@behind=$$(git submodule foreach -q ' \
+	  current=$$(git rev-parse HEAD); \
+	  remote=$$(git rev-parse origin/$(SUBMODULE_BRANCH) 2>/dev/null); \
+	  if [ "$$current" != "$$remote" ]; then \
+	    short=$$(echo $$remote | cut -c1-8); \
+	    echo "make update-$$name \t# will update to: $$short $$name"; \
+	  fi'); \
 	  if [ -z "$$behind" ]; then \
-		count=$$(git submodule | wc -l); \
+	    count=$$(git submodule | wc -l); \
 	    echo "All $$count submodules are up to date with their current branch"; \
 	  else \
 	    echo "Run the following commands to update submodules:"; \
-	    echo "$$behind"; \
+	    printf "$$behind\n"; \
 	  fi
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: production vagrant
+.PHONY: production vagrant check-submodules deploy-local-vagrant init-bundle init-submodules production-deploy \
+		production-parse-members staging-deploy staging-parse-members update-openaustralia-parser update-perllib \
+		update-phplib update-rblib update-twfy
 
 ALL: vagrant
 SHELL := /usr/bin/env bash
@@ -86,4 +88,3 @@ check-submodules:
 	    echo "Run the following commands to update submodules:"; \
 	    printf "$$behind\n"; \
 	  fi
-


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/openaustralia/issues/788

## What does this do?

Fixes the make check-submodules goal

## Why was this needed?

It was reporting everything ok when some needed updating

## Implementation/Deploy Steps (Optional)

Run `make check-submodules`

## Notes to reviewer (Optional)

```
ianh@ben:.../openaustralia (fix/check-submodules)$ make check-submodules 
Run the following commands to update submodules:
make update-twfy 	# will update to: 9b609b5b twfy
ianh@ben:.../openaustralia (fix/check-submodules)$ git co main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
ianh@ben:.../openaustralia (main)$ git co -b hotfix/brendas-3-pull-requests
Switched to a new branch 'hotfix/brendas-3-pull-requests'
ianh@ben:.../openaustralia (hotfix/brendas-3-pull)$ make update-twfy

=============================================================================
Checking TWFY is in sync with main branch
cd twfy && git fetch origin && git checkout main && git pull origin main
From https://github.com/openaustralia/twfy
 - [deleted]         (none)                         -> origin/feature/809-debug-mpinfoin-pl-script
 - [deleted]         (none)                         -> origin/feature/809-remove-duplicate-github-tasks
remote: Enumerating objects: 2, done.
remote: Counting objects: 100% (2/2), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 2 (delta 0), reused 2 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (2/2), 438 bytes | 438.00 KiB/s, done.
 * [new branch]      fix/820-getdivisions-api-calls -> origin/fix/820-getdivisions-api-calls
 + a10f2eb...94016c1 staging                        -> origin/staging  (forced update)
Already on 'main'
Your branch is behind 'origin/main' by 8 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
From https://github.com/openaustralia/twfy
 * branch            main       -> FETCH_HEAD
Updating d774e29..9b609b5
Fast-forward
 .github/workflows/php.yml                   | 10 ----------
 tests/RecessTest.php                        | 50 ++++++++++++++++++++++++++++++++++++++++++++++++++
 www/docs/hansard/index.php                  | 12 ++++--------
 www/includes/easyparliament/commentlist.php |  2 ++
 www/includes/easyparliament/page.php        |  5 +++--
 www/includes/easyparliament/recess.php      |  6 +++---
 6 files changed, 62 insertions(+), 23 deletions(-)
 create mode 100644 tests/RecessTest.php
git add --patch twfy && git commit -m "Update to latest TheyWorkForYou main branch"
diff --git a/twfy b/twfy
index d774e29..9b609b5 160000
--- a/twfy
+++ b/twfy
@@ -1 +1 @@
-Subproject commit d774e29d61da599ad9ba8f86e792c72a960a3863
+Subproject commit 9b609b5be1fa47a6bbf6554104abf05d6f89bbe1
(1/1) Stage this hunk [y,n,q,a,d,e,?]? y

[hotfix/brendas-3-pull-requests 553accf] Update 
```
