### PR TITLE
Fetch just the branch we are deploying to so the old submodule commit…

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -20,7 +20,7 @@ namespace :git do
 
       if test("[ -d #{cached_copy}/.git ]")
         within cached_copy do
-          execute :git, 'fetch', 'origin'
+          execute :git, 'fetch', 'origin', fetch(:branch)
           execute :git, 'reset', '--hard', "origin/#{fetch(:branch)}"
           execute :git, 'clean', '-d', '-x', '-f'
           execute :git, 'submodule', 'init'


### PR DESCRIPTION
## Relevant issue(s)

* https://github.com/openaustralia/infrastructure/issues/504

## What does this do?

Fetches just the branch we are deploying to so the old submodule commit doesn’t have to exist (which can happen when you do a force push)

## Why was this needed?

Because cap deploy broke.

I deployed main branch to production and staging using this fix. See before fix error log below.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

Error log before fix:
```bash
$ make staging-deploy
...
00:03 git:create_release
      01 mkdir -p /srv/www/staging/releases/20260513102856
    ✔ 01 deploy@openaustralia.org.au 0.108s
      02 git archive main | /usr/bin/env tar -x -f - -C /srv/www/staging/releases/20260513102856
    ✔ 02 deploy@openaustralia.org.au 0.112s
      03 git fetch origin
      03 From https://github.com/openaustralia/openaustralia
      03    80a28d2..b75465b  main       -> origin/main
      03  + d4a6a19...aabf14f staging    -> origin/staging  (forced update)
      03 Fetching submodule twfy
      03 From https://github.com/openaustralia/twfy
      03    9b609b5..0b09315  main       -> origin/main
      03  + 497599e...0b09315 staging    -> origin/staging  (forced update)
      03 fatal: remote error: upload-pack: not our ref 0a5b58a9cf5b721e362b072d3d66f7a83f67ccfa
      03 Errors during submodule fetch:
      03 	twfy
#<Thread:0x00007ce174c72838 /home/ianh/.local/share/mise/installs/ruby/3.4.9/lib/ruby/gems/3.4.0/gems/sshkit-1.25.0/lib/sshkit/runners/parallel.rb:8 run> terminated with exception (report_on_exception is true):
/home/ianh/.local/share/mise/installs/ruby/3.4.9/lib/ruby/gems/3.4.0/gems/sshkit-1.25.0/lib/sshkit/runners/parallel.rb:13:in 'block (2 levels) in SSHKit::Runner::Parallel#execute': Exception while executing as deploy@openaustralia.org.au: git exit status: 1 (SSHKit::Runner::ExecuteError)
git stdout: Nothing written
git stderr: From https://github.com/openaustralia/openaustralia
   80a28d2..b75465b  main       -> origin/main
 + d4a6a19...aabf14f staging    -> origin/staging  (forced update)
Fetching submodule twfy
From https://github.com/openaustralia/twfy
   9b609b5..0b09315  main       -> origin/main
 + 497599e...0b09315 staging    -> origin/staging  (forced update)
fatal: remote error: upload-pack: not our ref 0a5b58a9cf5b721e362b072d3d66f7a83f67ccfa
Errors during submodule fetch:
	twfy
```