### PR TITLE
Chore Update bundler to 4.0.12 so it keeps its own checksum in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,4 +73,4 @@ RUBY VERSION
   ruby 3.4.9
 
 BUNDLED WITH
-  4.0.9
+  4.0.12


### PR DESCRIPTION
## Relevant issue(s)

N/A - noticed when reviewing dependabot PRs

## What does this do?

Updates Gemfile.lock to use Bundler v4.0.12 instead of v4.0.9 

4.0.11 includes the relevant change:
* Lock the checksum of Bundler itself in the lockfile ← this is the key one

4.0.12 adds a useful improvement:
* Fix installing gems with native extensions + transitive dependencies

## Why was this needed?

`bundle install` was removing bundlers checksum from Gemfile.lock, causing local repo to be marked changed on simple tests.

## Implementation/Deploy Steps (Optional)

## Notes to reviewer (Optional)

Oddly, the checksum had been present in the previous Gemfile.lock despite it listing bundler 4.0.9, which doesn't officially support it