### PR TITLE
Adding composer to capistrano deploy

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -4,6 +4,7 @@ require 'capistrano/deploy'
 require 'capistrano/scm/git'
 install_plugin Capistrano::SCM::Git
 require 'capistrano/bundler'
+require 'capistrano/composer'
 # Check for this ruby manager first in openaustralia-parser:bin/run
 require 'capistrano/rbenv'
 require 'capistrano/tagging3'

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby file: ".ruby-version"
 
 gem 'capistrano', '~> 3.20'
 gem 'capistrano-bundler'
+gem 'capistrano-composer'
 gem 'capistrano-rbenv'
 gem "capistrano-tagging3", "~> 2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,8 @@ GEM
       sshkit (>= 1.9.0)
     capistrano-bundler (2.2.0)
       capistrano (~> 3.1)
+    capistrano-composer (0.0.6)
+      capistrano (>= 3.0.0.pre)
     capistrano-rbenv (2.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
@@ -45,6 +47,7 @@ DEPENDENCIES
   bcrypt_pbkdf (>= 1.0, < 2.0)
   capistrano (~> 3.20)
   capistrano-bundler
+  capistrano-composer
   capistrano-rbenv
   capistrano-tagging3 (~> 2.0)
   ed25519 (>= 1.2, < 2.0)
@@ -56,6 +59,7 @@ CHECKSUMS
   bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
   capistrano (3.20.1) sha256=b0d54ba5cf49bb194998bf6b427e889aa36ed05f545ecf7cc37acb9d529e9ae9
   capistrano-bundler (2.2.0) sha256=47b4cf2ea17ea132bb0a5cabc5663443f5190a54f4da5b322d04e1558ff1468c
+  capistrano-composer (0.0.6) sha256=dc32796263212a1e9ea4e573422a2fa893649805fb8fd2055901e26515fb3397
   capistrano-rbenv (2.2.0) sha256=3c8f39b7c624f3806630dcb475484bb3579aef07a40efe85089d83f64b0c35f5
   capistrano-tagging3 (2.0.0) sha256=cf676c5c8928bbcb59dda4b75dcf9bb096d5f4ae5641a1b5a5ac5ddbb3e136b3
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab

--- a/README.md
+++ b/README.md
@@ -75,6 +75,46 @@ To deploy the main branch to ([Production](https://www.openaustralia.org.au/)):
 
 For other things, like attempting to parse a day's speeches after a parsing error, you'll need to log into the server to run the script(s) manually.
 
+### PHP / Composer dependencies (twfy)
+
+The `twfy` web application uses PHP packages declared in `twfy/composer.json`
+(currently Eloquent / `illuminate/database`, plus dev tools like PHPUnit, Psalm
+and Phinx). The resulting `twfy/vendor/` directory is **gitignored** in the
+`twfy` submodule, so it is never committed or pushed.
+
+Capistrano fills that gap during deploy via the [capistrano-composer][cc] gem
+(loaded in [`Capfile`](Capfile) and configured in [`config/deploy.rb`](config/deploy.rb)):
+
+[cc]: https://github.com/capistrano/composer
+
+1. The custom `git:create_release` task clones the submodules and copies the
+   working tree into `release_path`, so `release_path/twfy/composer.json` is
+   present on the server.
+2. `capistrano-composer` automatically registers
+   `before 'deploy:updated', 'composer:install'`. We point it at the twfy
+   subdirectory with `set :composer_working_dir, -> { release_path.join('twfy') }`
+   and install with `--no-dev --prefer-dist --no-interaction --optimize-autoloader`.
+3. This produces `release_path/twfy/vendor/` before
+   `deploy:symlink_shared`, `deploy:compile_lockfile`, and the Apache restart
+   run. The application's `twfy/www/includes/easyparliament/init.php` does a
+   `require_once .../vendor/autoload.php`, so the dependency tree must be on
+   disk before Apache serves any traffic from the new release.
+4. On rollback the gem also runs `composer:install` before `deploy:reverted`,
+   so older releases get a matching `vendor/` if it has been pruned.
+
+Bumping a PHP dependency therefore needs **no special deploy step** — update
+`composer.json` / `composer.lock` in the `twfy` repo, push, bump the submodule
+pointer in this repo (`make update-twfy`), and deploy as usual.
+
+Server prerequisites (one-time, managed by Ansible, not by Capistrano):
+
+* `composer` on the `deploy` user's `$PATH`.
+* `php-cli` with the same extensions the runtime needs (at minimum
+  `mbstring`, `xml`, `curl`, `zip`, `mysql`).
+
+If either is missing the deploy fails loudly at the `composer:install` step
+rather than producing a silent 500 from a missing `vendor/autoload.php`.
+
 ## Updating images
 
 OpenAustralia attempts to grab the official profile photo for each MP

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,6 +13,16 @@ set :bundle_gemfile, 'openaustralia-parser/Gemfile'
 set :bundle_roles, :app
 set :bundle_config, { deployment: true }
 
+# Composer configuration (PHP dependencies for the twfy app).
+# composer.json lives in the twfy submodule, so override the default working
+# directory (which is release_path). capistrano/composer hooks composer:install
+# into `before deploy:updated`, which runs after our custom git:create_release
+# task has populated release_path, so release_path/twfy/composer.json exists by
+# the time composer runs.
+set :composer_roles, :app
+set :composer_working_dir, -> { release_path.join('twfy') }
+set :composer_install_flags, '--no-dev --prefer-dist --no-interaction --optimize-autoloader'
+
 # Use sudo for apache restart
 set :use_sudo, true
 


### PR DESCRIPTION
## Relevant issue(s)
part of 
 * https://github.com/openaustralia/openaustralia/issues/863

needs
 * https://github.com/openaustralia/infrastructure/pull/538
 
## What does this do?
This PR will add a Composer step to deployments for installing PHP source dependencies (it's Bundler, but for PHP)


## Why was this needed?

We're using Composer to manage PHP dependencies. Our new ORM will be installed via Composer.
