### PR TITLE
Prune stale branches when we deploy

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -21,10 +21,14 @@ namespace :git do
 
       if test("[ -d #{cached_copy}/.git ]")
         within cached_copy do
-          execute :git, 'fetch', 'origin', fetch(:branch)
+          execute :git, 'fetch', '--prune', 'origin', fetch(:branch)
           execute :git, 'reset', '--hard', "origin/#{fetch(:branch)}"
           execute :git, 'clean', '-d', '-x', '-f'
           execute :git, 'submodule', 'init'
+          # Prune stale remote-tracking refs first: deleted-then-reused branch
+          # names upstream (e.g. `test` replaced by `test/scripts`) otherwise
+          # make the submodule fetch below fail with a ref lock error.
+          execute :git, 'submodule', 'foreach', '--recursive', 'git remote prune origin'
           execute :git, 'submodule', 'update', '--recursive'
         end
       else


### PR DESCRIPTION

## Description

Prune dead branches from the server's local checkout during deploy.


## Motivation and Context

this error occurred when deploying to *staging* today:

```
 DEBUG [b0137ef7] 	 * [new branch]        doc/add-agents-md   -> origin/doc/add-agents-md
 DEBUG [b0137ef7] 	   fe49ce86..f543fc31  fix/perl-mysql84    -> origin/fix/perl-mysql84
 DEBUG [b0137ef7] 	   c74f04fb..5ce2c2dd  main                -> origin/main
 DEBUG [b0137ef7] 	 * [new branch]        remove/old-bindings -> origin/remove/old-bindings
 DEBUG [b0137ef7] 	error: cannot lock ref 'refs/remotes/origin/test/scripts': 'refs/remotes/origin/test' exists; cannot create 'refs/remotes/origin/test/scripts'
 ! [new branch]        test/scripts        -> origin/test/scripts  (unable to update local ref)
 DEBUG [b0137ef7] 	Errors during submodule fetch:

	twfy
make: *** [Makefile:23: staging-deploy] Error 1
```

It's complaining about a branch that no longer exists on the remote.


## How Has This Been Tested?

Today's production deploy relied on this change.

## Screenshots (if appropriate):

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
