### PR TITLE
Fix parse members command via Capistrano

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -130,7 +130,8 @@ namespace :parse do
   task :members do
     on roles(:app) do
       within current_path do
-        execute :bash, '-c', 'openaustralia-parser/bin/run parse-members.rb'
+        # No bash -c here, SSHKit already executes commands directly.
+        execute 'openaustralia-parser/bin/run', 'parse-members.rb'
       end
     end
   end


### PR DESCRIPTION

## Description

Production parse members isn't working when run remotely using Capistrano (instead of on the server itself)

```
$ make production-parse-members
bundle exec cap production parse:members
00:00 parse:members
      01 bash -c openaustralia-parser/bin/run parse-members.rb
      01 rspec not available
    ✔ 01 deploy@openaustralia.org.au 0.986s
```

This is because sshkit already escapes the command.

## Motivation and Context

I've changed how we define the command in the capfile so it will run

Now it works:

```
$ make production-parse-members 
bundle exec cap production parse:members
00:00 parse:members
      01 openaustralia-parser/bin/run parse-members.rb
      01 WARNING: Nokogiri was built against libxml version 2.13.9, but has dynamically loaded 2.9.14
      01 Loading config from: /srv/www/production/releases/20260817204755/openaustralia-parser/lib/../configuration.yml for production
      01 Reading members data...
      01 Running consistency checks...
      01 WARNING: No current member for Higgins
      01 WARNING: No current member for North Sydney
      01 Writing xml files /srv/www/production/shared/pwdata/members//{people.xml,representatives.xml,senators.xml,ministers.xml,divisions.xml}...


```
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
- [ ] Checked affected area manually on my own / staging system
<!--- Include details of your testing environment -->
<!--- Detail the tests you ran to see how your change affects other areas of the code, etc. -->
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
