### PR TITLE
Add agent skills configuration for engineering skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,26 @@ specific go-ahead for that exact action, right now, however routine the request 
 - The stack is old in places (README's own warning); check what a file actually targets before assuming modern
   Ruby/PHP idioms apply.
 
+## Agent skills
+
+Configuration the engineering skills read. These files describe how this repo works; edit them directly rather than
+re-running the setup skill.
+
+### Issue tracker
+
+Issues live as GitHub issues in `openaustralia/openaustralia`, driven by the `gh` CLI. See
+`docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The default five-label vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`.
+See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` and one `docs/adr/` at the root, both created lazily. The submodules are separate
+repositories and keep their own. See `docs/agents/domain.md`.
+
 ## Contributing
 
 This repository has no `CONTRIBUTING.md` or templates of its own; the org-wide ones in

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -50,4 +50,4 @@ morph.io. Never invent variants.
 
 If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
 
-> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because..._
+> _Contradicts ADR-0003 (submodule pointer bumps stay manual), but worth reopening because..._

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,53 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`AGENTS.md`** at the repo root. It is the canonical guidance for this repo; `CLAUDE.md` and
+  `.github/copilot-instructions.md` only point at it.
+- **`CONTEXT.md`** at the repo root, if it exists.
+- **`docs/adr/`**, if it exists. Read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them
+upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates
+them lazily when terms or decisions actually get resolved.
+
+## Layout: single-context
+
+This repo is **single-context**: one `CONTEXT.md` and one `docs/adr/` at the root.
+
+```
+/
+├── AGENTS.md
+├── CONTEXT.md                         ← created lazily by /domain-modeling
+└── docs/
+    ├── adr/                           ← created lazily by /domain-modeling
+    │   ├── 0001-....md
+    │   └── 0002-....md
+    └── agents/                        ← this directory
+```
+
+The six submodules (`twfy`, `openaustralia-parser`, `phplib`, `perllib`, `rblib`, `shlib`) are separate
+repositories, not workspace packages, so they are **not** contexts of this one. Domain docs for a submodule belong
+in that submodule's own repository. Don't write a `CONTEXT.md` or an ADR into a submodule checkout from here.
+
+If this repo ever does need per-context docs, the multi-context form is a root `CONTEXT-MAP.md` pointing at one
+`CONTEXT.md` per context, with context-scoped ADRs alongside each.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the
+term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal. Either you're inventing language the project
+doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+Use the exact service names in prose: Planning Alerts, Right to Know, They Vote for You, OpenAustralia.org.au and
+morph.io. Never invent variants.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because..._

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,66 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues in
+[`openaustralia/openaustralia`](https://github.com/openaustralia/openaustralia). Use the `gh` CLI for all
+operations.
+
+This is the umbrella repo, so it also carries cross-cutting issues for the whole project. Work on application
+behaviour belongs in the relevant submodule's own repository (see `AGENTS.md`), and so do its issues.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies. Follow the
+  org issue templates in [`openaustralia/.github`](https://github.com/openaustralia/.github/tree/main/.github/ISSUE_TEMPLATE);
+  this repo has none of its own.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+Never bulk-close issues. Present a not-reproducible or stale verdict as evidence and let a human decide, except for
+outright duplicates and issues whose context no longer exists.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage`
+reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either. Resolve with `gh pr view 42`
+and fall back to `gh issue view 42`.
+
+Note that Dependabot opens submodule and bundler PRs here daily. They are automated maintenance, not requests, so
+keep them out of any triage queue.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Opening pull requests
+
+Use the org pull request template from
+[`openaustralia/.github`](https://github.com/openaustralia/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md), and
+assign yourself: `gh pr create --assignee @me`. Note AI involvement and the model in the PR body.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -16,6 +16,10 @@ from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
 
+All five labels exist on the repo. Two were renamed from earlier labels rather than created, so older issues
+and comments may still refer to them by the old name: `needs-info` was `needs-reproduction`, and
+`ready-for-human` was `ready`.
+
 ## Other labels in this repo
 
 These sit outside the five canonical roles and the skills don't read them. Leave them alone unless you are

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,27 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings
+used in this repo's issue tracker. This repo keeps the default vocabulary, so both columns match.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (for example "apply the AFK-ready triage label"), use the corresponding label string
+from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Other labels in this repo
+
+These sit outside the five canonical roles and the skills don't read them. Leave them alone unless you are
+deliberately triaging with them:
+
+- `needs-dev-env` for issues that can only be verified with a working development environment. Given the state of
+  the local Vagrantfile and `docker.sh` (see `AGENTS.md`), a fair number of issues sit here.
+- `stale` for probable close candidates from a triage sweep, pending human confirmation.
+- Type and area labels such as `bug`, `task`, `New feature`, `improvement`, `parser`, `web app`, `votes`, `API`.


### PR DESCRIPTION
## Description

Scaffolds `docs/agents/` and adds an `## Agent skills` section to `AGENTS.md` pointing at it. This is the per-repo
configuration the mattpocock engineering skills (`/triage`, `/to-tickets`, `/to-spec`, `/wayfinder`, `/domain-modeling`)
read to learn how this repo actually works.

Three files:

- `docs/agents/issue-tracker.md` - issues live as GitHub issues here, driven by the `gh` CLI. Records the org issue
  and PR templates from `openaustralia/.github` (this repo has none of its own), the rule that issues aren't
  bulk-closed, and a note that Dependabot's daily submodule/bundler PRs are automated maintenance rather than
  requests to triage. The "PRs as a request surface" flag is left off.
- `docs/agents/triage-labels.md` - the default five-role vocabulary (`needs-triage`, `needs-info`,
  `ready-for-agent`, `ready-for-human`, `wontfix`), plus the repo's existing labels that sit outside those roles
  (`needs-dev-env`, `stale`, the type/area labels) so triage leaves them alone.
- `docs/agents/domain.md` - single-context layout, and an explicit rule that the six submodules are separate
  repositories rather than contexts of this one, so nothing writes a `CONTEXT.md` or ADR into a submodule checkout.

Two judgement calls worth flagging:

- The block goes in `AGENTS.md`, not `CLAUDE.md`. The setup skill's default is to edit `CLAUDE.md` when it exists,
  but #908 made `CLAUDE.md` a one-line `@AGENTS.md` pointer, so canonical content belongs in `AGENTS.md`.
- No `CONTEXT.md` or `docs/adr/` is created. `/domain-modeling` creates those lazily when there's an actual term or
  decision to record, and empty stubs would just be noise.

The label vocabulary has already been applied directly to the repo, so the skills don't reference labels that
don't exist. Labels aren't versioned, so this is a record of what changed rather than something the merge
performs, and closing this PR wouldn't undo it. `needs-reproduction` was renamed to `needs-info` (5 issues carried across) and `ready` to
`ready-for-human` (0 issues); `needs-triage`, `ready-for-agent` and `wontfix` were created. `needs-dev-env`, `stale`
and the type/area labels are untouched. Both renames are recorded in `docs/agents/triage-labels.md` so older
references to the previous names still make sense.

## Motivation and Context

Follows #908, which gave this repo its agent-instruction files. That covered what the repo is; this covers where
work is tracked and how the skills should interact with it.

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system - documentation only. The `gh` invocations,
  label names and issue counts were verified against the live repo; the submodule list against `.gitmodules`.
- [ ] Ran automated tests on my own system
- [ ] Confirmed it passed the GitHub actions tests

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---

AI disclosure: written with Claude Code (model claude-opus-5), for human review before merge.

