### PR TITLE
Add a manual workflow to deploy any branch to staging

### DIFF
--- a/.github/workflows/deploy-staging-branch.yml
+++ b/.github/workflows/deploy-staging-branch.yml
@@ -1,0 +1,121 @@
+---
+name: Deploy a branch to staging
+
+# Manual only - for previewing an unmerged branch on staging before it's
+# reviewed/merged to main (same thing `STAGING_BRANCH=that-branch make
+# staging-deploy` does locally). Whoever runs this must have write access to
+# trigger the workflow at all.
+#
+# Shares the "deploy-staging" concurrency group with deploy-staging.yml (the
+# automatic on-merge-to-main workflow) below, so the two can never run at the
+# same time and stomp on each other's release.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch/tag/ref to deploy to staging"
+        required: true
+
+permissions:
+  contents: read
+  # Required to federate with AWS via OIDC (configure-aws-credentials below) -
+  # no long-lived AWS credentials are stored in this repo as a result.
+  id-token: write
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # The "staging" environment holds DEPLOY_SSH_KEY and AWS_DEPLOY_ROLE_ARN,
+    # same as deploy-staging.yml - but its deployment branch policy only
+    # allows main, which would block this workflow's whole point (deploying
+    # something that isn't main yet). Configure a second, wider-scoped
+    # environment for this workflow under Settings > Environments if that
+    # policy needs relaxing, or leave "staging" as-is if manual triggering
+    # (already gated on write access) is protection enough.
+    environment: staging
+    steps:
+      - name: Check out repository
+        # actions/checkout v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set up Ruby
+        # ruby/setup-ruby v1.321.0
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b
+        with:
+          bundler-cache: true
+
+      # Port 22 is closed on the webserver security group - deploy reaches the
+      # server the same way operators already do (infrastructure repo's
+      # bin/ssh-config), by tunnelling SSH through an AWS Systems Manager
+      # session instead of a direct network connection. This step is the only
+      # thing that needs AWS credentials; everything after it is plain SSH.
+      - name: Configure AWS credentials
+        # aws-actions/configure-aws-credentials v6.2.3
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ap-southeast-2
+
+      - name: Install the SSM Session Manager plugin
+        # Not preinstalled on GitHub-hosted runners - needed locally for the
+        # ProxyCommand below (`aws ssm start-session` shells out to it).
+        run: |
+          curl -fsSL "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o /tmp/session-manager-plugin.deb
+          sudo dpkg -i /tmp/session-manager-plugin.deb
+
+      # Deliberately not using a marketplace "ssh deploy" action here: keeping
+      # the deploy key handling to plain, auditable shell with no third-party
+      # code in the loop.
+      - name: Start ssh-agent
+        run: |
+          eval "$(ssh-agent -s)"
+          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
+          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
+
+      - name: Add deploy key
+        run: ssh-add - <<< "${{ secrets.DEPLOY_SSH_KEY }}"
+
+      # Resolves the instance ID by tag rather than hardcoding one, same as
+      # bin/ssh-config does for operators - it goes stale across a blue/green
+      # cutover or AMI refresh otherwise. Capistrano's own ssh_options already
+      # sets verify_host_key: :accept_new_or_local_tunnel
+      # (openaustralia/config/deploy.rb) - written with exactly this "reached
+      # via a ProxyCommand tunnel, not a direct connection" case in mind, so
+      # no known_hosts pre-population (the old ssh-keyscan step, which needed
+      # the now-closed port 22 itself) is needed. StrictHostKeyChecking below
+      # is redundant defense-in-depth on top of that, not the thing actually
+      # governing Net::SSH's own behaviour.
+      - name: Point SSH at the deploy host through SSM
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          instance_id=$(aws ec2 describe-instances \
+            --filters "Name=tag:PublicHostname,Values=www.openaustralia.org.au" "Name=instance-state-name,Values=running" \
+            --query "Reservations[].Instances[].InstanceId" --output text)
+          if [ "$(echo "$instance_id" | wc -w)" -ne 1 ]; then
+            echo "::error::Expected exactly one running instance tagged PublicHostname=www.openaustralia.org.au, got: '$instance_id'"
+            exit 1
+          fi
+          cat >> ~/.ssh/config <<EOF
+          Host openaustralia.org.au
+              ProxyCommand sh -c "aws ssm start-session --target $instance_id --document-name AWS-StartSSHSession --parameters portNumber=%p"
+              StrictHostKeyChecking accept-new
+          EOF
+
+      - name: Deploy branch to staging
+        # STAGING_BRANCH is what config/deploy/staging.rb actually reads (see
+        # `set :branch, ENV.fetch('STAGING_BRANCH', 'main')`) - same variable
+        # `make staging-deploy` uses today. Capistrano fetches this ref
+        # straight from GitHub itself (git:create_release), not from this
+        # job's own checkout above - that checkout is only so bundler/Ruby
+        # setup match the branch being deployed.
+        env:
+          STAGING_BRANCH: ${{ inputs.branch }}
+        run: bundle exec cap staging deploy


### PR DESCRIPTION
## What

A third GitHub Actions workflow, `deploy-staging-branch.yml`: `workflow_dispatch` with a required `branch` input, deploys that branch/tag/ref to staging. For previewing an unmerged branch on staging before it's reviewed/merged to `main` - same thing `STAGING_BRANCH=that-branch make staging-deploy` already does locally (see AGENTS.md's `update-*`/deploy gotchas).

Otherwise a straight copy of `deploy-production.yml`'s own branch-input pattern (checkout the given ref, same AWS OIDC + SSM plumbing), retargeted at the `staging` Capistrano stage/environment/deploy key instead of production's.

Shares `deploy-staging.yml`'s `deploy-staging` concurrency group, so the automatic on-merge-to-main deploy and a manual branch preview can never run at the same time and stomp on each other's release.

## Stacked on #935

Depends on the same SSM/OIDC plumbing that PR sets up (`AWS_DEPLOY_ROLE_ARN`, the SSM ProxyCommand steps) - based on `feature/staging-auto-deploy`, not `main`. Needs the same prerequisites #935 itself needs (openaustralia/infrastructure#710, #714) before it'll actually work.

## Note on the staging environment's branch policy

The `staging` GitHub Environment's deployment branch policy (set up for #935) restricts it to `main` - which would block this workflow's whole point. That policy likely needs relaxing (or this workflow needs its own, wider-scoped environment) before this is actually usable; flagged in a comment in the workflow file itself. Left as a decision for whoever configures the Environment, rather than guessing at the right policy here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)