### PR TITLE
Add workflow_dispatch to the staging deploy workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,15 +1,19 @@
 ---
 name: Deploy to staging
 
-# Runs only on a push to main - which on this repo only ever happens when a
+# Runs on a push to main - which on this repo only ever happens when a
 # maintainer merges an approved, reviewed PR (branch protection blocks direct
 # pushes and force-pushes). Forked PRs can never trigger this workflow and are
 # never handed the deploy key: GitHub does not expose secrets to pull_request
 # runs from forks, and this workflow doesn't listen for that event anyway.
+# workflow_dispatch allows a maintainer to re-run a staging deploy manually
+# from the Actions tab without needing a new commit; it's still gated by the
+# same repo write access and the "staging" environment's branch policy below.
 on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

This PR adds `workflow_dispatch` as a trigger on `deploy-staging.yml`,
alongside the existing `push` trigger. A maintainer can now start a staging
deploy manually from the Actions tab, without needing a new commit on main.

## Motivation and Context

The workflow currently only runs on a push to main. A maintainer sometimes
needs to re-run a staging deploy - for example after fixing an unrelated
Actions permissions issue - without waiting for a new commit.

## How Has This Been Tested?

- [ ] Not yet tested live. The workflow currently fails on an unrelated
      GitHub Actions org-permissions issue (openaustralia/infrastructure#724
      fixes that), so a manual run can't fully succeed until that lands.
- [x] Confirmed the YAML is valid and `workflow_dispatch: {}` doesn't change
      the existing push-trigger behaviour or the environment/branch-policy
      gate on who can deploy.

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
