### PR TITLE
Write twfy's own commit SHA to REVISION for Sentry release tracking

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -44,6 +44,15 @@ namespace :git do
       # Copy contents (not the directory itself) to release path
       execute :mkdir, '-p', release_path
       execute :cp, '-a', "#{cached_copy}/.", "#{release_path}/"
+
+      # twfy/REVISION: this submodule's own HEAD, for Sentry release tracking
+      # (twfy's init.php reads it) - not the umbrella repo's own commit, which
+      # Capistrano's default deploy:set_current_revision would capture instead
+      # (via git:set_current_revision, itself no-op here: repo_path is never
+      # populated by this custom task). It's twfy's code that actually runs,
+      # so it's twfy's commit that needs to identify a deploy in Sentry.
+      twfy_revision = capture(:git, '-C', "#{cached_copy}/twfy", 'rev-parse', 'HEAD').strip
+      execute :bash, '-c', "\"echo #{twfy_revision} > #{release_path}/twfy/REVISION\""
     end
   end
 end


### PR DESCRIPTION
## Description

Adds one step to `Capfile`'s custom `git:create_release` task: after copying the release into place, write the `twfy` submodule's own `HEAD` commit SHA to `twfy/REVISION` in the release.

## Motivation and Context

Companion to [openaustralia/twfy#238](https://github.com/openaustralia/twfy/pull/238), which adds Sentry release tracking to twfy's own `init.php` - it reads this file to tag captured errors with the exact deployed commit.

Capistrano's default `deploy:set_current_revision` task already writes a `REVISION` file (unconditionally, as part of `deploy:updating`) - but it wouldn't do the right thing here even though it still runs:

- It's populated by `git:set_current_revision`, which resolves the revision from `repo_path` (the standard bare-mirror-clone Capistrano would normally maintain) - but this repo's `git:create_release` is fully custom (needed because `git archive` drops submodule content), and never touches `repo_path` at all. That default population step is effectively inert here.
- Even if it did work, it would capture the **umbrella repo's** own commit, not `twfy`'s - and it's `twfy`'s PHP code that actually runs and produces the errors Sentry needs to track.

So this writes `twfy/REVISION` explicitly, from the exact same `cached-copy/twfy` checkout that already gets copied into the release a couple of lines above.

## How Has This Been Tested?

- [x] `ruby -c Capfile` - syntax OK
- [x] No Ruby lint/test tooling configured in this repo (per `AGENTS.md`: "not a development environment") - this is a small, mechanical addition to an existing, already-battle-tested task in the same file, using the same `execute`/`capture` primitives it already uses elsewhere
- [ ] Confirmed it passed the GitHub actions tests

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Assisted-by: Claude Code:claude-sonnet-5